### PR TITLE
로그인/회원가입 API 연동

### DIFF
--- a/src/components/auth/RegisterAgreement.tsx
+++ b/src/components/auth/RegisterAgreement.tsx
@@ -5,6 +5,7 @@ import { styled } from '../../lib/styles/stitches.config';
 import { registerFormItems } from '../../lib/texts/texts';
 import { RoundButton } from '../common';
 import { openNaverSSO } from '../../lib/api/auth';
+import { useUser } from '../../hooks';
 
 import { CheckboxItem } from './CheckboxItem';
 
@@ -27,6 +28,7 @@ export const RegisterAgreement = ({
   const [isCheckedAll, setIsCheckedAll] = useState(false);
   // BasicTerm, PersonalInfo, SMS, Email
   const [checkedList, setCheckedLists] = useState([false, false, false, false]);
+  const { sso } = useUser();
 
   const onClickShowMore = () => {
     setIsShowAll(true);
@@ -68,6 +70,16 @@ export const RegisterAgreement = ({
     setIsMobile((window.innerWidth < mobileLargeWidth) ? true : false);
     const mql = window.matchMedia(`screen and (max-width: ${mobileLargeWidth}px)`);
     mql.addEventListener('change', screenChange);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    window.onNaverAuthSuccess = ({ code, state }: { code: string, state: string }) => {
+      sso({
+        provider: 'naver',
+        code,
+        state,
+      });
+    };
     return () => mql.removeEventListener('change', screenChange);
   }, []);
 

--- a/src/components/auth/RegisterAgreement.tsx
+++ b/src/components/auth/RegisterAgreement.tsx
@@ -4,7 +4,7 @@ import { rem } from 'polished';
 import { styled } from '../../lib/styles/stitches.config';
 import { registerFormItems } from '../../lib/texts/texts';
 import { RoundButton } from '../common';
-import { openNaverSSO } from '../../lib/api/auth';
+import { getNaverAuthUrl } from '../../lib/api/auth';
 import { useUser } from '../../hooks';
 
 import { CheckboxItem } from './CheckboxItem';
@@ -65,21 +65,16 @@ export const RegisterAgreement = ({
     setIsMobile(matches);
   };
 
+  const onClickNaverLogin = () => {
+    const naverAuthUrl = getNaverAuthUrl();
+    window.location.href = naverAuthUrl;
+  };
+
   useEffect(() => {
     const mobileLargeWidth = 640; // @mobileLarge
     setIsMobile((window.innerWidth < mobileLargeWidth) ? true : false);
     const mql = window.matchMedia(`screen and (max-width: ${mobileLargeWidth}px)`);
     mql.addEventListener('change', screenChange);
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    window.onNaverAuthSuccess = ({ code, state }: { code: string, state: string }) => {
-      sso({
-        provider: 'naver',
-        code,
-        state,
-      });
-    };
     return () => mql.removeEventListener('change', screenChange);
   }, []);
 
@@ -89,7 +84,7 @@ export const RegisterAgreement = ({
       <SNSBlock>
         <SNSSubtitle>SNS 계정으로 간편하게 시작하기</SNSSubtitle>
         <SelectSNSItem>
-          <SNSItemTemplateForTest onClick={openNaverSSO}>
+          <SNSItemTemplateForTest onClick={onClickNaverLogin}>
             {isMobile && <><SocialIconTemp>N</SocialIconTemp>네이버 계정으로 가입하기</>}
           </SNSItemTemplateForTest>
           <SNSItemTemporary />

--- a/src/components/auth/RegisterAgreement.tsx
+++ b/src/components/auth/RegisterAgreement.tsx
@@ -5,7 +5,6 @@ import { styled } from '../../lib/styles/stitches.config';
 import { registerFormItems } from '../../lib/texts/texts';
 import { RoundButton } from '../common';
 import { getNaverAuthUrl } from '../../lib/api/auth';
-import { useUser } from '../../hooks';
 
 import { CheckboxItem } from './CheckboxItem';
 
@@ -28,7 +27,6 @@ export const RegisterAgreement = ({
   const [isCheckedAll, setIsCheckedAll] = useState(false);
   // BasicTerm, PersonalInfo, SMS, Email
   const [checkedList, setCheckedLists] = useState([false, false, false, false]);
-  const { sso } = useUser();
 
   const onClickShowMore = () => {
     setIsShowAll(true);

--- a/src/containers/auth/LoginForm.tsx
+++ b/src/containers/auth/LoginForm.tsx
@@ -3,10 +3,13 @@ import React, { useEffect, useState } from 'react';
 import { rem } from 'polished';
 
 import { styled } from '../../lib/styles/stitches.config';
-import { openNaverSSO } from '../../lib/api/auth';
+import { getNaverAuthUrl } from '../../lib/api/auth';
+import { rootSelector } from '../../stores';
 
 const LoginForm = () => {
   const [isMobile, setIsMobile] = useState(false);
+
+  rootSelector((state) => console.log(state.auth.userData));
 
   const screenChange = (event: MediaQueryListEvent) => {
     const { matches } = event;
@@ -28,7 +31,7 @@ const LoginForm = () => {
         <SNSBlock>
           <SNSSubtitle>SNS 계정으로 간편하게 시작하기</SNSSubtitle>
           <SelectSNSItem>
-            <SNSItemTemplateForTest onClick={openNaverSSO}>
+            <SNSItemTemplateForTest onClick={getNaverAuthUrl}>
               {isMobile && <><SocialIconTemp>N</SocialIconTemp>네이버 계정 로그인</>}
             </SNSItemTemplateForTest>
             <SNSItemTemplate />

--- a/src/containers/auth/RegisterForm.tsx
+++ b/src/containers/auth/RegisterForm.tsx
@@ -1,14 +1,16 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { rem } from 'polished';
 
 import { styled } from '../../lib/styles/stitches.config';
 import { RegisterAgreement } from '../../components/auth';
 import { RegisterField } from '../../components/auth/RegisterField';
+import { rootSelector } from '../../stores';
 
 import type { RegisterPayload } from '../../stores/auth';
 
 export const RegisterForm = () => {
   const [pageStats, setPageStats] = useState(0);
+  const authState = rootSelector(state => state.auth);
 
   const [registerForm, setRegisterForm] = useState<RegisterPayload>({
     userId: '',
@@ -23,6 +25,12 @@ export const RegisterForm = () => {
     workSpecified: '',
     careerLength: '',
   });
+
+  useEffect(() => {
+    if (authState.userData?.newMember) {
+      setPageStats(1);
+    }
+  }, [authState.userData?.newMember]);
 
   const toPageNext = () => {
     setPageStats(pageStats + 1);

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,23 +1,23 @@
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { actions } from '../stores/auth';
+import { thunks } from '../stores/auth';
 
-import type { LoginPayload,  RegisterPayload } from '../stores/auth';
+import type { LoginPayload, RegisterPayload } from '../stores/auth';
 
 export default function useUser() {
   const dispatch = useDispatch();
 
   const sso = useCallback((payload: LoginPayload) => {
-    dispatch(actions.sso(payload));
+    dispatch(thunks.sso(payload));
   }, []);
 
   const logout = useCallback(() => {
-    dispatch(actions.logout());
+    dispatch(thunks.logout());
   }, []);
 
   const additionalInfo = useCallback((payload: RegisterPayload) => {
-    dispatch(actions.additionalInfo(payload));
+    dispatch(thunks.additionalInfo(payload));
   }, []);
 
   return { sso, logout, additionalInfo };

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -10,7 +10,7 @@ export const openNaverSSO = () => {
 
   window.open(
     request_url,
-    'windowname',
+    'popup',
     'width=430, height=500, location=no, status=no, scrollbars=yes',
   );
 };

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,6 +1,6 @@
 export const login = ({/* noop */});
 
-export const openNaverSSO = () => {
+export const getNaverAuthUrl = () => {
   const client_id = process.env.NEXT_PUBLIC_NAVER_TOKEN_CID || '';
   const redirect_uri = encodeURI(
     `${process.env.NEXT_PUBLIC_URL || ''}/login/authSocial/naver`,
@@ -8,9 +8,5 @@ export const openNaverSSO = () => {
   const state_string = Math.random().toString(36).substr(2, 11);
   const request_url = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${client_id}&state=${state_string}&redirect_uri=${redirect_uri}`;
 
-  window.open(
-    request_url,
-    'popup',
-    'width=430, height=500, location=no, status=no, scrollbars=yes',
-  );
+  return request_url;
 };

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -3,7 +3,7 @@
 import axios from 'axios';
 
 const client = axios.create({
-  baseURL: process.env.NEXT_BACKEND_ADDR,
+  baseURL: process.env.NEXT_PUBLIC_BACKEND_ADDR,
 });
 
 export default client;

--- a/src/pages/login/authSocial/naver.tsx
+++ b/src/pages/login/authSocial/naver.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 const CallbackNaver = () => {
   useEffect(() => {
@@ -6,17 +6,17 @@ const CallbackNaver = () => {
     const params = new URL(href).searchParams;
     const code = params.get('code');
     const state = params.get('state');
-    console.log({ code });
-    console.log({ state });
-    /*
-      이곳에서 code를 백엔드 서버로 전송합니다.
-      백엔드에서 loginForm쪽으로 결과를 반환하도록 하여, 로그인 결과를 알 수 있도록 합니다.
-    */
 
-    // 페이지 내에서 할 모든 작업이 끝나면 페이지를 종료합니다.
-    //window.close();
+    if (code === null || state === null) {
+      alert('정상적인 접근이 아닙니다.');
+      window.close();
+      return;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+    window.opener.onNaverAuthSuccess({ code, state });
+    window.close();
   }, []);
-  return <div></div>;
+  return null;
 };
 
 export default CallbackNaver;

--- a/src/pages/login/authSocial/naver.tsx
+++ b/src/pages/login/authSocial/naver.tsx
@@ -20,11 +20,12 @@ const CallbackNaver = () => {
     window.close();
     return;
   }
+
   sso({
-    provider: 'naver',
     code,
     state,
   });
+
   void router.push('/register');
   return null;
 };

--- a/src/pages/login/authSocial/naver.tsx
+++ b/src/pages/login/authSocial/naver.tsx
@@ -1,21 +1,31 @@
-import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+
+import { useUser } from '../../../hooks';
 
 const CallbackNaver = () => {
-  useEffect(() => {
-    const href = window.location.href;
-    const params = new URL(href).searchParams;
-    const code = params.get('code');
-    const state = params.get('state');
+  const { sso } = useUser();
+  const router = useRouter();
 
-    if (code === null || state === null) {
-      alert('정상적인 접근이 아닙니다.');
-      window.close();
-      return;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
-    window.opener.onNaverAuthSuccess({ code, state });
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const params = new URL(window.location.href).searchParams;
+  const code = params.get('code');
+  const state = params.get('state');
+
+  if (code === null || state === null) {
+    alert('정상적인 접근이 아닙니다.');
     window.close();
-  }, []);
+    return;
+  }
+  sso({
+    provider: 'naver',
+    code,
+    state,
+  });
+  void router.push('/register');
   return null;
 };
 

--- a/src/stores/auth/actions.ts
+++ b/src/stores/auth/actions.ts
@@ -1,26 +1,34 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 
-import type { LoginPayload, RegisterPayload } from './types';
+import client from '../../lib/api/client';
 
-export const sso = createAsyncThunk(
+import type {
+  LoginPayload, LoginResponse, RegisterPayload,
+} from './types';
+
+export const sso = createAsyncThunk<LoginResponse, LoginPayload, { rejectValue: undefined }>(
   'auth/sso',
-  // FIXME: async thunk 내부 구현에서 axios 요청을 보내면서 await을 사용할 때 아래 eslint 무시 구문 제거하기
-  // eslint-disable-next-line @typescript-eslint/require-await
-  async ({ provider }: LoginPayload, thunkAPI) => {
+  async ({ provider, code, state }, { rejectWithValue }) => {
     try {
-      // TODO: 로그인 요청을 하고 결과를 반환합니다.
-      // 결과는 아래의 auth slice의 state에 저장될 값입니다.
+      const resp = await client.post<LoginResponse>('/auth/naver', {
+        code,
+        state,
+      });
+
+      return resp.data;
     } catch (error: unknown) {
       if (axios.isAxiosError(error)) {
-        return thunkAPI.rejectWithValue(error.response?.data);
+        // FIXME: null 대신 다른 값 반환하기
+        return rejectWithValue(undefined);
       } else {
-        // TODO: axios에서 일어난 오류가 아닐경우 처리하기
+        // FIXME: null 대신 다른 값 반환하기
+        return rejectWithValue(undefined);
       }
     }
   },
 );
-  
+
 export const logout = createAsyncThunk(
   'auth/logout',
   async () => {
@@ -28,7 +36,7 @@ export const logout = createAsyncThunk(
     // 로그아웃은 별다른 결과값을 반환하지 않으므로 오류 핸들링을 내부에서 별도로 하지 않아도 될 것입니다.
   },
 );
-  
+
 export const additionalInfo = createAsyncThunk(
   'auth/register',
   // FIXME: async thunk 내부 구현에서 axios 요청을 보내면서 await을 사용할 때 아래 eslint 무시 구문 제거하기
@@ -36,7 +44,7 @@ export const additionalInfo = createAsyncThunk(
   async (payload: RegisterPayload, thunkAPI) => {
     try {
       // TODO: 회원가입 요청을 하고 결과를 반환합니다.
-      // 회원가입 후 바로 로그인이 된다고 가정하고 login과 비슷하게 보일러 플레이트를 만들어놨는데 
+      // 회원가입 후 바로 로그인이 된다고 가정하고 login과 비슷하게 보일러 플레이트를 만들어놨는데
       // 만약 아니라면, 회원가입 요청 후 내려오는 값이 별 쓸모가 없을 것 같으니 logout처럼 간단하게 처리하면 될 것 같습니다.
     } catch (error: unknown) {
       if (axios.isAxiosError(error)) {

--- a/src/stores/auth/index.ts
+++ b/src/stores/auth/index.ts
@@ -1,11 +1,11 @@
 import reducer from './reducer';
-import * as actions from './actions';
+import * as thunks from './thunks';
 
 import type {
   LoginPayload, RegisterPayload, UserState, UserData,
 } from './types';
 
-export { reducer, actions };
+export { reducer, thunks };
 export type {
   LoginPayload, RegisterPayload, UserState, UserData,
 };

--- a/src/stores/auth/index.ts
+++ b/src/stores/auth/index.ts
@@ -1,5 +1,11 @@
 import reducer from './reducer';
 import * as actions from './actions';
 
+import type {
+  LoginPayload, RegisterPayload, UserState, UserData,
+} from './types';
+
 export { reducer, actions };
-export * from './types';
+export type {
+  LoginPayload, RegisterPayload, UserState, UserData,
+};

--- a/src/stores/auth/reducer.ts
+++ b/src/stores/auth/reducer.ts
@@ -2,10 +2,9 @@ import { createSlice } from '@reduxjs/toolkit';
 
 import {
   sso, logout, additionalInfo,
-} from './actions';
+} from './thunks';
 
 import type { UserState } from './types';
-
 
 const initialState: UserState = {};
 

--- a/src/stores/auth/reducer.ts
+++ b/src/stores/auth/reducer.ts
@@ -1,26 +1,25 @@
 import { createSlice } from '@reduxjs/toolkit';
-import axios from 'axios';
 
 import {
-  sso, logout, additionalInfo, 
+  sso, logout, additionalInfo,
 } from './actions';
 
 import type { UserState } from './types';
 
 
-const initialState: UserState = {
-  userData: null,
-  error: null,
-};
+const initialState: UserState = {};
 
-                                                                                                                          
+
 const { reducer } = createSlice({
   name: 'auth',
   initialState,
   reducers: {},
   extraReducers: (builder) => {
     builder.addCase(sso.fulfilled, (state, action) => {
-      // TODO: 로그인 성공 후 서버에서 내려온 값을 state에 저장합니다.
+      const { payload } = action;
+      state.userData = {
+        ...payload,
+      };
     });
 
     builder.addCase(sso.rejected, (state, action) => {

--- a/src/stores/auth/thunks.ts
+++ b/src/stores/auth/thunks.ts
@@ -9,7 +9,7 @@ import type {
 
 export const sso = createAsyncThunk<LoginResponse, LoginPayload, { rejectValue: undefined }>(
   'auth/sso',
-  async ({ provider, code, state }, { rejectWithValue }) => {
+  async ({ code, state }, { rejectWithValue }) => {
     try {
       const resp = await client.post<LoginResponse>('/auth/naver', {
         code,

--- a/src/stores/auth/types.d.ts
+++ b/src/stores/auth/types.d.ts
@@ -8,7 +8,12 @@ export type LoginPayload = {
   code: string,
   state: string,
 };
-  
+
+export type LoginResponse = {
+  newMember: boolean,
+  userId: number,
+};
+
 // 회원가입 액션 페이로드 타입
 export type RegisterPayload = {
   userId: string,
@@ -33,6 +38,6 @@ export type UserData = {
 
 //초기 상태 타입
 export type UserState = {
-  userData: LoginPayload | null,
-  error: unknown,
+  userData?: LoginResponse,
+  error?: unknown,
 };

--- a/src/stores/auth/types.d.ts
+++ b/src/stores/auth/types.d.ts
@@ -4,7 +4,6 @@
 
 // 로그인 액션 페이로드 타입
 export type LoginPayload = {
-  provider: 'naver',
   code: string,
   state: string,
 };

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,10 +1,13 @@
 import { combineReducers } from 'redux';
+import { TypedUseSelectorHook, useSelector } from 'react-redux';
 
 import loading from './loading/reducer';
 import auth from './auth/reducer';
 
 const rootReducer = combineReducers({ loading, auth });
 
-export default rootReducer;
-
 export type RootState = ReturnType<typeof rootReducer>;
+
+export const rootSelector: TypedUseSelectorHook<RootState> = useSelector;
+
+export default rootReducer;


### PR DESCRIPTION
- 네이버 아이디로 로그인 후 `/register` 페이지로 이동
- 신규 유저일 경우 추가정보 입력 페이지로 이동

위 기능까지 작업했습니다.

디스코드에서 이야기 나눈대로, 다음 작업을 하려면 페이지 분리가 먼저 선행되어야 할 것 같아서 여기서 끊고 리뷰 요청 드립니다!